### PR TITLE
multipathdの話をREADMEに記述

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -111,6 +111,24 @@ sudo systemctl start iscsid
 sudo systemctl enable iscsid
 ```
 
+multipathd が干渉しないようにする（参考: <https://longhorn.io/kb/troubleshooting-volume-with-multipath/>）
+
+```bash
+sudo vi /etc/multipath.conf
+```
+
+以下を追記する。
+
+```conf
+blacklist {
+    devnode "^sd[a-z0-9]+"
+}
+```
+
+```bash
+sudo systemctl restart multipathd.service
+```
+
 ### flux をインストール(初回のみ)
 
 参考: https://fluxcd.io/flux/installation/


### PR DESCRIPTION
これをしないと、以下の警告が出てPodがContainerCreatingの状態から動かなくなる

```
Warning  FailedMount  30s (x15 over 14m)  kubelet            MountVolume.MountDevice failed for volume "pvc-6532bab5-3410-443b-a04a-855503ba3808" : rpc error: code = Internal desc = mount failed: exit status 32
Mounting command: mount
Mounting arguments: -t ext4 -o defaults /dev/longhorn/pvc-6532bab5-3410-443b-a04a-855503ba3808 /var/lib/kubelet/plugins/kubernetes.io/csi/driver.longhorn.io/1a2c65b20e8a7021ee883ef84c403969dd9ea9e72ad026e3bdb98803c1d40dcb/globalmount
Output: mount: /var/lib/kubelet/plugins/kubernetes.io/csi/driver.longhorn.io/1a2c65b20e8a7021ee883ef84c403969dd9ea9e72ad026e3bdb98803c1d40dcb/globalmount: /dev/longhorn/pvc-6532bab5-3410-443b-a04a-855503ba3808 already mounted or mount point busy.
       dmesg(1) may have more information after failed mount system call.
```

参考：https://longhorn.io/kb/troubleshooting-volume-with-multipath/