### PR TITLE
stagingブランチをrelease branchとしてpath filterを働かせる

### DIFF
--- a/.github/workflows/stg-deploy.yaml
+++ b/.github/workflows/stg-deploy.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: path-filter
         with:
+          base: staging
           filters: |
             kube:
               - "kubernetes/**"


### PR DESCRIPTION
デフォルトではmainブランチとの差分を調べてしまう。stagingブランチはreleaseブランチなので、正しく差分を検出できていなかった。